### PR TITLE
fix: 修复日志乱码问题

### DIFF
--- a/Logan/LoganSwift/LoganSwift/LoganSwift.swift
+++ b/Logan/LoganSwift/LoganSwift/LoganSwift.swift
@@ -90,10 +90,7 @@ extension LoganImpl {
         let threadNumber = self.threadNumber()
         let isMain = Thread.current.isMainThread
         let threadName = Thread.current.name != nil ? (Thread.current.name! as NSString) : ("" as NSString)
-        
-        let log = UnsafeMutablePointer<Int8>(mutating: (text as NSString).utf8String)
-        let thread_name = UnsafeMutablePointer<Int8>(mutating: threadName.utf8String)
-        
+
         if LOGANUSEASL {
             printLog(text, type: type)
         }
@@ -103,6 +100,9 @@ extension LoganImpl {
         }
         
         async { [unowned self] in
+            let log = UnsafeMutablePointer<Int8>(mutating: (text as NSString).utf8String)
+            let thread_name = UnsafeMutablePointer<Int8>(mutating: threadName.utf8String)
+
             let today = self.currentDate
             if !self.lastLogDate.isEmpty && self.lastLogDate != today {
                 clogan_flush()


### PR DESCRIPTION
这里 `NSString.utf8String` 指向的内存是由 `NSString` 实例管理的，当前函数执行完成后 `text` 和 `threadName` 就会被回收。

当 async 传入的闭包执行时，`log` 跟 `thread_number` 指向的内存地址可能就存放了其它的数据，导致日志里写入了未知的内容，产生乱码。

这里我把 `log` 和 `thread_number ` 的声明放到闭包里，隐式引用 `text` 和 `threadNumber`，保证 `clogan_write ` 调用时它们还是存活状态。